### PR TITLE
fix: type definitions to include install function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-
 - Add a module export with an `install` function. This fixes builds in newer Vue apps written in TypeScript
 - Add `@vue/runtime-core` for being able to import `App` type for correct type information on the install function
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add a module export with an `install` function. This fixes builds in newer Vue apps written in TypeScript
+- Add `@vue/runtime-core` for being able to import `App` type for correct type information on the install function
+
 ## [1.0.0] - 2021-01-19
 ### Changed
 - Migrate honeybadger-js dependency to @honeybadger-io/js 3.0.0

--- a/honeybadger-vue.d.ts
+++ b/honeybadger-vue.d.ts
@@ -1,14 +1,24 @@
-import Vue from 'vue';
-import Honeybadger from 'honeybadger-js';
+// This is required for Vue 3 createApp support
+import { App } from '@vue/runtime-core'
+import _Vue from 'vue'
+import Honeybadger from '@honeybadger-io/js';
 
 interface HoneybadgerVue {
-    notify(...args: any[]): any;
-    setContext<T extends object>(context: T): Honeybadger;
-    resetContext(): Honeybadger;
+  notify(...args: any[]): any;
+  setContext<T extends object>(context: T): typeof Honeybadger;
+  resetContext(): typeof Honeybadger;
+}
+
+declare module '@honeybadger-io/vue' {
+  const HoneybadgerVue: {
+    install(app: App | typeof _Vue, options?: any): void
+  }
+
+  export default HoneybadgerVue;
 }
 
 declare module 'vue/types/vue' {
-    interface Vue {
-        $honeybadger: HoneybadgerVue;
-    }
+  interface Vue {
+    $honeybadger: HoneybadgerVue;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4310,6 +4310,31 @@
         }
       }
     },
+    "@vue/reactivity": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.5.tgz",
+      "integrity": "sha512-3xodUE3sEIJgS7ntwUbopIpzzvi7vDAOjVamfb2l+v1FUg0jpd3gf62N2wggJw3fxBMr+QvyxpD+dBoxLsmAjw==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.5.tgz",
+      "integrity": "sha512-Cnyi2NqREwOLcTEsIi1DQX1hHtkVj4eGm4hBG7HhokS05DqpK4/80jG6PCCnCH9rIJDB2FqtaODX397210plXg==",
+      "dev": true,
+      "requires": {
+        "@vue/reactivity": "3.0.5",
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+      "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
     "@babel/runtime": "^7.9.2",
+    "@vue/runtime-core": "^3.0.5",
     "ajv": "^6.12.2",
     "autoprefixer": "^10.0.0",
     "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Fixes the type definitions that started failing on newer Vue apps with TypeScript. The TypeScript compiler was yelling about the missing install function on the exported object from HoneybadgerVue instance.

## Related PRs
Fixes #519 

## Todos
- [X ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout umarov:type-definition-fix
> npm link
```
1. Create a Vue 3 TypeScript app
2. `npm i @honeybadger-io/vue`
3. Update `main.ts` to `import HoneybadgerVue from '@honeybadger-io/vue'`
4. Add `.use(HoneybadgerVue)` to `createApp(App)` function
5. There will be type errors and warnings about the `install` function not being there in the type definitions
    - You can confirm this by running `npm run build`
6. Now link the locally pulled version
7. `npm link @honeybadger-io/vue` 
8. If you are testing this in VS Code, restart the TypeScript server if the error didn't go away
7. There should be no type errors in VS Code
    - Do a production build `npm run build` to confirm it again
