### PR TITLE
Fix typescript definition errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix TypeScript errors in Vue 2
+
 
 ## [1.0.1] - 2021-02-17
-
 ### Fixed
 - Add a module export with an `install` function. This fixes builds in newer Vue apps written in TypeScript
-- Add `@vue/runtime-core` for being able to import `App` type for correct type information on the install function
 
 ## [1.0.0] - 2021-01-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://badge.fury.io/js/%40honeybadger-io%2Fvue.svg)](https://badge.fury.io/js/%40honeybadger-io%2Fvue)
 > [Vue.js integration for Honeybadger.io](https://www.honeybadger.io/for/javascript/?utm_source=github&utm_medium=readme&utm_campaign=vue&utm_content=Vue.js+integration+for+Honeybadger.io)
 
+**Note:** The latest release of this project supports Vue.js v2.x. See the [vue3](https://github.com/honeybadger-io/honeybadger-vue/tree/vue3) branch for v3.x support.
+
 ## Documentation and Support
 
 For comprehensive documentation and support, [check out our documentation site](https://docs.honeybadger.io/lib/javascript/index.html).

--- a/honeybadger-vue.d.ts
+++ b/honeybadger-vue.d.ts
@@ -1,24 +1,21 @@
-// This is required for Vue 3 createApp support
-import { App } from '@vue/runtime-core'
-import _Vue from 'vue'
-import Honeybadger from '@honeybadger-io/js';
 
-interface HoneybadgerVue {
-  notify(...args: any[]): any;
-  setContext<T extends object>(context: T): typeof Honeybadger;
-  resetContext(): typeof Honeybadger;
-}
+// Type definitions for honeybadger.js vue integration
+// Project: https://github.com/honeybadger-io/honeybadger-vue
 
 declare module '@honeybadger-io/vue' {
+  import Vue from 'vue'
+
   const HoneybadgerVue: {
-    install(app: App | typeof _Vue, options?: any): void
+    install(app: typeof Vue, options?: any): void
   }
 
   export default HoneybadgerVue;
 }
 
 declare module 'vue/types/vue' {
+  import Honeybadger from '@honeybadger-io/js';
+
   interface Vue {
-    $honeybadger: HoneybadgerVue;
+    $honeybadger: typeof Honeybadger;
   }
 }


### PR DESCRIPTION
I think #778 broke TypeScript on Vue 2 apps a little. Hoping this fixes it.