### PR TITLE
#865 (Vue.js v2) Log errors to console 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Log error to console in development (#865)
 
 ## [1.0.3] - 2021-02-18
 ### Fixed

--- a/src/error-logging.js
+++ b/src/error-logging.js
@@ -1,0 +1,12 @@
+import { generateComponentTrace } from './vue-debug'
+
+export function logError (Vue, error, vm, info) {
+  const message = `Error in ${info}: "${error && error.toString()}"`
+
+  const trace = vm ? generateComponentTrace(vm) : ''
+  if (Vue.config.warnHandler) {
+    Vue.config.warnHandler.call(null, message, vm, trace)
+  } else {
+    console.error(`[Vue warn]: ${message}${trace}`)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import Honeybadger from '@honeybadger-io/js'
+import { generateComponentTrace } from './vue-debug'
 
 const HoneybadgerVue = {
   install (Vue, options) {
@@ -10,10 +11,10 @@ const HoneybadgerVue = {
     Vue.prototype.$honeybadger = Vue.$honeybadger
     const chainedErrorHandler = Vue.config.errorHandler
     const extractContext = function (vm) {
-      var options = typeof vm === 'function' && vm.cid != null ? vm.options : vm._isVue ? vm.$options ||
+      const options = typeof vm === 'function' && vm.cid != null ? vm.options : vm._isVue ? vm.$options ||
         vm.constructor.options : vm || {}
-      var name = options.name || options._componentTag
-      var file = options.__file
+      const name = options.name || options._componentTag
+      const file = options.__file
       return {
         isRoot: vm.$root === vm,
         name: name,
@@ -22,10 +23,33 @@ const HoneybadgerVue = {
         file: file
       }
     }
+    const shouldLogError = () => {
+      if (Vue.config.warnHandler) {
+        return true
+      }
+
+      const hasConsole = typeof console !== 'undefined';
+      const isDebug = Vue.config.debug || process.env.NODE_ENV !== 'production'
+      return hasConsole && isDebug
+    }
+    const logError = (error, vm, info) => {
+      const message = `Error in ${info}: "${error && error.toString()}"`
+
+      const trace = vm ? generateComponentTrace(vm) : ''
+      if (Vue.config.warnHandler) {
+        Vue.config.warnHandler.call(null, message, vm, trace)
+      } else {
+        console.error(`[Vue warn]: ${message}${trace}`)
+      }
+    }
     Vue.config.errorHandler = (error, vm, info) => {
       honeybadger.notify(error, { context: { vm: extractContext(vm), info: info } })
       if (typeof chainedErrorHandler === 'function') {
         chainedErrorHandler.call(this.Vue, error, vm, info)
+      }
+
+      if (shouldLogError()) {
+        logError(error, vm, info)
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Honeybadger from '@honeybadger-io/js'
-import { generateComponentTrace } from './vue-debug'
+import { logError } from './error-logging'
 
 const HoneybadgerVue = {
   install (Vue, options) {
@@ -11,8 +11,12 @@ const HoneybadgerVue = {
     Vue.prototype.$honeybadger = Vue.$honeybadger
     const chainedErrorHandler = Vue.config.errorHandler
     const extractContext = function (vm) {
-      const options = typeof vm === 'function' && vm.cid != null ? vm.options : vm._isVue ? vm.$options ||
-        vm.constructor.options : vm || {}
+      const options = typeof vm === 'function' && vm.cid != null
+        ? vm.options
+        : vm._isVue
+          ? vm.$options ||
+        vm.constructor.options
+          : vm || {}
       const name = options.name || options._componentTag
       const file = options.__file
       return {
@@ -28,20 +32,11 @@ const HoneybadgerVue = {
         return true
       }
 
-      const hasConsole = typeof console !== 'undefined';
+      const hasConsole = typeof console !== 'undefined'
       const isDebug = Vue.config.debug || process.env.NODE_ENV !== 'production'
       return hasConsole && isDebug
     }
-    const logError = (error, vm, info) => {
-      const message = `Error in ${info}: "${error && error.toString()}"`
 
-      const trace = vm ? generateComponentTrace(vm) : ''
-      if (Vue.config.warnHandler) {
-        Vue.config.warnHandler.call(null, message, vm, trace)
-      } else {
-        console.error(`[Vue warn]: ${message}${trace}`)
-      }
-    }
     Vue.config.errorHandler = (error, vm, info) => {
       honeybadger.notify(error, { context: { vm: extractContext(vm), info: info } })
       if (typeof chainedErrorHandler === 'function') {
@@ -49,7 +44,7 @@ const HoneybadgerVue = {
       }
 
       if (shouldLogError()) {
-        logError(error, vm, info)
+        logError(Vue, error, vm, info)
       }
     }
   }

--- a/src/vue-debug.js
+++ b/src/vue-debug.js
@@ -1,0 +1,74 @@
+/**
+ * This was taken from https://github.com/vuejs/vue/blob/master/src/core/util/debug.js.
+ * The method generateStackTrace is used to log errors the same way as Vue logs them when errorHandler is not set.
+ */
+
+const classifyRE = /(?:^|[-_])(\w)/g
+const classify = str => str
+  .replace(classifyRE, c => c.toUpperCase())
+  .replace(/[-_]/g, '')
+
+const formatComponentName = (vm, includeFile) => {
+  if (vm.$root === vm) {
+    return '<Root>'
+  }
+  const options = typeof vm === 'function' && vm.cid != null
+    ? vm.options
+    : vm._isVue
+      ? vm.$options || vm.constructor.options
+      : vm || {}
+  let name = options.name || options._componentTag
+  const file = options.__file
+  if (!name && file) {
+    const match = file.match(/([^/\\]+)\.vue$/)
+    name = match && match[1]
+  }
+
+  return (
+    (name ? `<${classify(name)}>` : `<Anonymous>`) +
+    (file && includeFile !== false ? ` at ${file}` : '')
+  )
+}
+
+const repeat = (str, n) => {
+  let res = ''
+  while (n) {
+    if (n % 2 === 1) res += str
+    if (n > 1) str += str
+    n >>= 1
+  }
+  return res
+}
+
+export const generateComponentTrace = vm => {
+  if (vm._isVue && vm.$parent) {
+    const tree = []
+    let currentRecursiveSequence = 0
+    while (vm) {
+      if (tree.length > 0) {
+        const last = tree[tree.length - 1]
+        if (last.constructor === vm.constructor) {
+          currentRecursiveSequence++
+          vm = vm.$parent
+          continue
+        } else if (currentRecursiveSequence > 0) {
+          tree[tree.length - 1] = [last, currentRecursiveSequence]
+          currentRecursiveSequence = 0
+        }
+      }
+      tree.push(vm)
+      vm = vm.$parent
+    }
+    return '\n\nfound in\n\n' + tree
+      .map((vm, i) => `${
+        i === 0 ? '---> ' : repeat(' ', 5 + i * 2)
+      }${
+        Array.isArray(vm)
+          ? `${formatComponentName(vm[0])}... (${vm[1]} recursive calls)`
+          : formatComponentName(vm)
+      }`)
+      .join('\n')
+  } else {
+    return `\n\n(found in ${formatComponentName(vm)})`
+  }
+}

--- a/src/vue-debug.js
+++ b/src/vue-debug.js
@@ -25,7 +25,7 @@ const formatComponentName = (vm, includeFile) => {
   }
 
   return (
-    (name ? `<${classify(name)}>` : `<Anonymous>`) +
+    (name ? `<${classify(name)}>` : '<Anonymous>') +
     (file && includeFile !== false ? ` at ${file}` : '')
   )
 }

--- a/test/unit/specs/HoneyBadgerVue.spec.js
+++ b/test/unit/specs/HoneyBadgerVue.spec.js
@@ -16,10 +16,13 @@ describe('HoneybadgerVue', () => {
   }
 
   beforeEach(function () {
+    process.env.NODE_ENV = 'test'
+
     jest.resetModules()
 
     global.console = {
-      log: jest.fn()
+      log: jest.fn(),
+      error: jest.fn()
     }
 
     Vue = require('vue')
@@ -97,7 +100,9 @@ describe('HoneybadgerVue', () => {
   //   })
   // })
 
-  it("should invoke Honeybadger's notify", (done) => {
+  it("should invoke Honeybadger's notify without logging error in console", (done) => {
+    process.env.NODE_ENV = 'production'
+    Vue.config.debug = false
     const constructor = factory()
 
     sandbox.spy(constructor.$honeybadger, 'notify')
@@ -105,6 +110,20 @@ describe('HoneybadgerVue', () => {
     constructor.config.errorHandler(err, { $root: true, $options: {} }, 'some descriptive context')
     afterNotify(done, function () {
       expect(constructor.$honeybadger.notify.called).toBeTruthy()
+      expect(global.console.error).not.toHaveBeenCalled()
+    })
+  })
+
+  it("should invoke Honeybadger's notify and log error in console", (done) => {
+    Vue.config.debug = true
+    const constructor = factory()
+
+    sandbox.spy(constructor.$honeybadger, 'notify')
+    const err = new Error('oops')
+    constructor.config.errorHandler(err, { $root: true, $options: {} }, 'some descriptive context')
+    afterNotify(done, function () {
+      expect(constructor.$honeybadger.notify.called).toBeTruthy()
+      expect(global.console.error).toHaveBeenCalledTimes(1);
     })
   })
 


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #865 .

Similar to [Sentry](https://github.com/getsentry/sentry-javascript/blob/master/packages/vue/src/errorhandler.ts#L46), log errors to console if not in production or `Vue.config.debug = true`.

## Todos
- [x] Tests
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> vue create my-app
> cd my-app
> npm add @honeybadger-io/vue --save
```
1. In `main.js`, setup Honeybadger and enable debug mode in `Vue.config`:
```
import Vue from 'vue'
import App from './App.vue'
import HoneybadgerVue from '@honeybadger-io/vue'

const config = {
  apiKey: 'project api key',
  environment: 'dev',
}

Vue.config.productionTip = false
Vue.config.debug = true

Vue.use(HoneybadgerVue, config)

new Vue({
  render: h => h(App),
}).$mount('#app')

```
2. Add a button to throw an error in `App.vue`:
```
<template>
  <div id="app">
    <img alt="Vue logo" src="./assets/logo.png">
    <HelloWorld msg="Welcome to Your Vue.js App"/>
    <button @click="throwError">Throw an error</button>
  </div>
</template>

<script>
import HelloWorld from './components/HelloWorld.vue'

export default {
  name: 'App',
  components: {
    HelloWorld
  },
  methods: {
    throwError() {
      console.log('throwing error');
      throw new Error('error');
    }
  }
}
</script>
```
3. `npm run dev`
4. Click on `Throw an error`
5. Error should be reported in Honeybadger **and** to console