### PR TITLE
Enable dependabot for vue3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    target-branch: "vue3"
+    directory: "/"
+    versioning-strategy: "increase"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     directory: "/"
     versioning-strategy: "increase"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependabot"


### PR DESCRIPTION
## Status
**READY**

## Description
vue3 branch is falling behind on deps.
Note: Target branch is master because `dependabot.yml` needs to be configured on default branch. However dependabot will create PRs targetted to vue3 branch.