### PR TITLE
revert type definition to use install as init method does not exist on Vue.Plugin definition

### DIFF
--- a/honeybadger-vue.d.ts
+++ b/honeybadger-vue.d.ts
@@ -12,7 +12,7 @@ declare module '@vue/runtime-core' {
 }
 
 declare var HoneybadgerVue: {
-  init(app: App, options?: Partial<BrowserConfig>): void
+  install(app: App, options?: Partial<BrowserConfig>): void
 }
 
 export default HoneybadgerVue

--- a/honeybadger-vue.test-d.ts
+++ b/honeybadger-vue.test-d.ts
@@ -11,7 +11,7 @@ const config = {
 }
 
 const app = createApp({})
-HoneybadgerVue.init(app, config)
+HoneybadgerVue.install(app, config)
 
 app.$honeybadger.setContext({
   foo: 'bar'


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
This fixes a Typescript error when installing `HoneybadgerVue` as a Vue 3 plugin in a Vue 3 Typescript enabled project.

```typescript
const app = createApp(App)
app.use(HoneybadgerVue, options)
```

The type mismatch error:

```
TS2345: Argument of type '{ init(app: App , options?: Partial  | undefined): void; }' is not assignable to parameter of type 'Plugin_2'
```

where `Plugin_2` (an alias to `Plugin`) is defined in `@vue/runtime-core` as 
```typescript
declare type Plugin_2 = (PluginInstallFunction & {
    install?: PluginInstallFunction;
}) | {
    install: PluginInstallFunction;
};
export { Plugin_2 as Plugin }
```

## Related PRs
List related PRs against other branches: none

## Todos
- [x] Tests
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
```bash
> git pull --prune
> git checkout <branch>
> yarn tsd
```
